### PR TITLE
Fix wsl detection in validateCommand function

### DIFF
--- a/src/brackets.ts
+++ b/src/brackets.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode'
 
 export function parseBrackets(text: string | Buffer): vscode.Range[] {
-	if (text instanceof Buffer)
-		text = text.toString()
+	text = text.toString()
 	const lines = text.split('\n')
 	const bracketPairs: vscode.Range[] = []
 	let endPos = new vscode.Position(0, 0)

--- a/src/getEnvironmentVariables.ts
+++ b/src/getEnvironmentVariables.ts
@@ -44,7 +44,7 @@ function validateCommand(command: string): CommandData | null {
 		return null
 	}
 
-	return { command: validCommand, wsl: command.startsWith('wsl ') }
+	return { command: validCommand, wsl: validCommand.startsWith('wsl ') }
 }
 
 export type EnvironmentVariables = {

--- a/src/norminette.ts
+++ b/src/norminette.ts
@@ -44,7 +44,7 @@ function normDecrypt(normLine: string): NormInfo {
 	}
 	catch (e) {
 		try {
-			const [fullText, token_or_line] = normLine.match(/(?:\s|\033\[.*m)*Error: Unrecognized (token|line) .*/)
+			const [fullText, token_or_line] = normLine.match(/(?:\s|\x1b\[.*m)*Error: Unrecognized (token|line) .*/)
 			if (token_or_line === 'token') {
 				var [_, errorText, line_str, col_str] = normLine.match(/.* (Unrecognized token) line (\d+), col (\d+)/)
 				var line = parseInt(line_str) - 1

--- a/src/norminette.ts
+++ b/src/norminette.ts
@@ -5,7 +5,7 @@ async function execAsync(command: string, timeoutMs: number = 10_000): Promise<{
 	return new Promise(resolve => {
 		const abort = new AbortController()
 		const timeout = setTimeout(() => abort.abort(), timeoutMs)
-		exec(`${command}`, { signal: abort.signal }, (error, stdout, stderr) => {
+		exec(`${command} --no-colors`, { signal: abort.signal }, (error, stdout, stderr) => {
 			clearTimeout(timeout)
 			// @ts-ignore
 			const wasAborted = error.code === 'ABORT_ERR' || error.message === 'The operation was aborted'


### PR DESCRIPTION
Hi,

The **validateCommand** function's regex was expecting the output of `norminette -v` to be `3.x.x`. But since [commit ef5e1d9](https://github.com/42school/norminette/commit/ef5e1d99353331c92888a59d04bdf8ea7ae64a38) the output now includes different informations such as the python version.

I updated the Regex to reflect this change, you can see it in action here: https://regex101.com/r/srf0mi/1

I originaly came only to update the Regex, but I ended up refactoring a little to remove code duplication in this function.  But to be able to launch the extension I also had to fix some small TS issues that Wepback was throwing at me. Namely converting an escape sequence from octal to hexadecimal and changing an assignement to have proper type inference.

I then also added the `--no-color` flag to get a clean output from the command, otherwise a bunch of escape characters were includes in the decorations.

Please let me know if you'd prefer this to be splitted in different PRs or if you see anything wrong in this PR.