### PR TITLE
Fix process leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 				},
 				"codam-norminette-3.command": {
 					"type": "string",
-					"default": "norminette",
+					"default": "exec norminette",
 					"description": "Specifies norminette command"
 				},
 				"codam-norminette-3.commandTimeoutMs": {


### PR DESCRIPTION
When norminette hangs infinitely, for example on this code:
```c
int main(void) {
    printf()
}
```

It won't get killed because the extension only kills the bash shell, not norminette itself, causing a lot of running norminette processes after a while.

In this pull request I made the bash shell run norminette via exec, which makes norminette replace the shell, which makes it so when the process is killed, norminette is killed.